### PR TITLE
Fix kanji result ordering

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,8 +63,8 @@ You can also lookup english keyword with kanji too
     (default) 譲
         譲: defer
     (default) 図書館
-        書: write
         図: map
+        書: write
         館: bldg.
 
 To quit, type ```.q```.

--- a/rtklookup/collection.py
+++ b/rtklookup/collection.py
@@ -47,6 +47,8 @@ class KanjiCollection(object):
     def __init__(self):
         # a plain list of Kanji objects
         self.kanjis = []  # type: List[Kanji]
+        self.keyword_to_obj = {}
+        self.kanji_to_obj = {}
 
         # did we load any stories?
         self.stories_available = False
@@ -91,6 +93,9 @@ class KanjiCollection(object):
             kanji_obj.keyword = keyword
 
             self.kanjis.append(kanji_obj)
+            self.keyword_to_obj[keyword] = kanji_obj
+            self.kanji_to_obj[kanji] = kanji_obj
+
 
     def load_file_stories(self):
         try:
@@ -186,14 +191,12 @@ class KanjiCollection(object):
                     found.append(kanji_obj)
 
         else:
-            for kanji_obj in self.kanjis:
-                if word == kanji_obj.keyword:
-                    found.append(kanji_obj)
-                else:
-                    # in case the words consists of kanji
-                    for letter in word:
-                        if letter == kanji_obj.kanji:
-                            found.append(kanji_obj)
+            if word in self.keyword_to_obj:
+                found.append(self.keyword_to_obj[word])
+            else:
+                for letter in word:
+                    if letter in self.kanji_to_obj:
+                        found.append(self.kanji_to_obj[letter])
 
         return found
 

--- a/rtklookup/collection.py
+++ b/rtklookup/collection.py
@@ -49,6 +49,7 @@ class KanjiCollection(object):
         self.kanjis = []  # type: List[Kanji]
         self.keyword_to_obj = {}
         self.kanji_to_obj = {}
+        self.index_to_obj = {}
 
         # did we load any stories?
         self.stories_available = False
@@ -95,6 +96,7 @@ class KanjiCollection(object):
             self.kanjis.append(kanji_obj)
             self.keyword_to_obj[keyword] = kanji_obj
             self.kanji_to_obj[kanji] = kanji_obj
+            self.index_to_obj[index] = kanji_obj
 
 
     def load_file_stories(self):
@@ -161,11 +163,9 @@ class KanjiCollection(object):
         word = word.replace('_', ' ')
         found = []
 
-        if word.isdigit():
+        if word.isdigit() and word in self.index_to_obj:
             # searching for RTK index
-            for kanji_obj in self.kanjis:
-                if kanji_obj.index == word:
-                    found.append(kanji_obj)
+            found.append(self.index_to_obj[word])
 
         elif word[-1] == "?":
             sword = word[:-1]

--- a/rtklookup/collection.py
+++ b/rtklookup/collection.py
@@ -190,13 +190,14 @@ class KanjiCollection(object):
                 if is_found:
                     found.append(kanji_obj)
 
+        elif word in self.keyword_to_obj:
+            found.append(self.keyword_to_obj[word])
+
         else:
-            if word in self.keyword_to_obj:
-                found.append(self.keyword_to_obj[word])
-            else:
-                for letter in word:
-                    if letter in self.kanji_to_obj:
-                        found.append(self.kanji_to_obj[letter])
+            # Map each kanji to the corresponding keyword
+            for letter in word:
+                if letter in self.kanji_to_obj:
+                    found.append(self.kanji_to_obj[letter])
 
         return found
 


### PR DESCRIPTION
Kanji result is now ordered by Heisig's index. It would be more natural to order it by user input.

For example:
```
    (default) 図書館
        図: map
        書: write
        館: bldg.
```
Instead of:
```
    (default) 図書館
        書: write
        図: map
        館: bldg.
```

